### PR TITLE
商品出品機能を実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,3 +88,4 @@ gem 'ancestry'
 
 gem 'devise-i18n'
 gem 'devise-i18n-views'
+gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,6 +171,10 @@ GEM
     ipaddress (0.8.3)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
+    jquery-rails (4.3.5)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     kgio (2.11.3)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -348,6 +352,7 @@ DEPENDENCIES
   font-awesome-sass
   haml-rails
   jbuilder (~> 2.5)
+  jquery-rails
   listen (>= 3.0.5, < 3.2)
   mini_magick
   mysql2 (>= 0.4.4, < 0.6.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,4 +13,6 @@
 //= require rails-ujs
 //= require activestorage
 //= require turbolinks
+//= require jquery
+//= require jquery_ujs
 //= require_tree .

--- a/app/assets/javascripts/items.coffee
+++ b/app/assets/javascripts/items.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -1,0 +1,34 @@
+$(document).on('turbolinks:load', ()=> {
+  // 画像用のinputを生成する関数
+  const buildFileField = (index)=> {
+    const html = `<div data-index="${index}" class="js-file_group">
+                    <input class="js-file" type="file"
+                    name="item[images_attributes][${index}][image]"
+                    id="item_images_attributes_${index}_src"><br>
+                    <div class="js-remove">削除</div>
+                  </div>`;
+    return html;
+  }
+  // プレビュー用のimgタグを生成する関数
+  // const buildImg = (index, url)=> {
+  //   const html = `<img data-index="${index}" src="${url}" width="100px" height="100px">`;
+  //   return html;
+  // }
+  // file_fieldのnameに動的なindexをつける為の配列
+  let fileIndex = [1,2,3,4,5,6,7,8,9,10];
+  console.log("test");
+  $('#image-box').on('change', '.js-file', function(e) {
+    console.log("testtetstest");
+    // fileIndexの先頭の数字を使ってinputを作る
+    $('#image-box').append(buildFileField(fileIndex[0]));
+    fileIndex.shift();
+    // 末尾の数に1足した数を追加する
+    fileIndex.push(fileIndex[fileIndex.length - 1] + 1)
+  });
+
+  $('#image-box').on('click', '.js-remove', function() {
+    $(this).parent().remove();
+    // 画像入力欄が0個にならないようにしておく
+    if ($('.js-file').length == 0) $('#image-box').append(buildFileField(fileIndex[0]));
+  });
+});

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,5 +4,24 @@ class ItemsController < ApplicationController
 
   def show
   end
+
+  def new
+    @item = Item.new
+    @item.images.new
+    # @item.users << current_user
+  end
+
+  def create
+    # binding.pry
+    @item = Item.new(item_params)
+    @item.save
+    redirect_to items_path
+  end
   
+  private
+  def item_params
+    # 仮でユーザーIDを１にしている
+    params.require(:item).permit(:name, :explanation, :category_id, :size, :brand_name, :condition_id, :status_id, :delivery_fee_id, :prefecture_id, :delivery_day_id, :price, images_attributes: [:image]).merge(user_id: 1,status_id: 1) 
+  end
+
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,3 +1,4 @@
 class Image < ApplicationRecord
+  mount_uploader :image, ImageUploader
   belongs_to :item
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -9,4 +9,6 @@ class Item < ApplicationRecord
   belongs_to :user
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to_active_hash :prefecture
+
+  accepts_nested_attributes_for :images, allow_destroy: true
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -4,8 +4,11 @@ class Item < ApplicationRecord
   belongs_to :category
   belongs_to :condition
   belongs_to :delivery_fee
-  belongs_to_active_hash :prefecture
   belongs_to :delivery_day
   belongs_to :status
   belongs_to :user
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to_active_hash :prefecture
+
+  accepts_nested_attributes_for :images, allow_destroy: true
 end

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -1,118 +1,137 @@
 .selmain
-  %form.selmain-form
-    .selmain-form_box
-      .selimage
-        .selimage-title
-          %label 出品画像
-          %span.required 必須
-        %p 最大10枚までアップロードできます
-        .selimage-function
-          .selimage-function_input
-            %label.clkarea
-              %input.clkarea-input{:type => 'file'}
-              = icon('fa', 'camera', class: 'clkarea-icon')
-              %p.clkarea-text クリックしてファイルをアップロード
-        %p.selimage-error 入力してください
-    %hr
-    .selmain-form_box
-      .selname
-        .selname-title
-          %label 商品名
-          %span.required 必須
-        .selname-function
-          .selname-function_input
-            %input.selname-text{:placeholder => '40文字まで', :type => 'text'}
-        %p.selname-error 入力してください
-      .selspace
-      .selname
-        .selname-title
-          %label 商品の説明
-          %span.required 必須
-        .selname-function
-          .selname-function_input
-            %input.selexplanation-text{:placeholder => '1,000文字以内', :type => 'text'}
-        %p 0/1000
-        %p.selexplanation-error 入力してください
-    %hr
-    .selmain-form_box
-      .seldetail
-        %p.seldetail-main 商品の詳細
-        .seldetail-title
-          %label カテゴリー
-          %span.required 必須
-        .seldetail-function
-          .seldetail-function_input
-            %select.selcategory-select
-              %option{:value => '0'}選択してください
-        %p.selcategory-error 選択してください
-      .selspace
-      .seldetail
-        .seldetail-title
-          %label ブランド
-          %span.discretion 任意
-        .seldetail-function
-          .seldetail-function_input
-            %input.selbrand-text{:placeholder => '例）シャネル', :type => 'text'}
-      .selspace
-      .seldetail
-        .seldetail-title
-          %label 商品の状態
-          %span.required 必須
-        .seldetail-function
-          .seldetail-function_input
-            %select.selstatus-select
-              %option{:value => '0'}選択してください
-        %p.selstatus-error 選択してください
-    %hr
-    .selmain-form_box
-      .seldelovery
-        %p.seldelovery-main 配送について？
-        .seldelovery-title
-          %label 配送料の負担
-          %span.required 必須
-        .seldelovery-function
-          .seldelovery-function_input
-            %select.seldelfee-select
-              %option{:value => '0'}選択してください
-        %p.seldelfee-error 選択してください
-      .selspace
-      .seldelovery
-        .seldelovery-title
-          %label 発送元の地域
-          %span.required 必須
-        .seldelovery-function
-          .seldelovery-function_input
-            %select.selshiori-select
-              %option{:value => '0'}選択してください
-        %p.selshiori-error 選択してください
-      .selspace
-      .seldelovery
-        .seldelovery-title
-          %label 発送までの日数
-          %span.required 必須
-        .seldelovery-function
-          .seldelovery-function_input
-            %select.selshiday-select
-              %option{:value => '0'}選択してください
-        %p.selshiday-error 選択してください
-    %hr
-    .selmain-form_box
-      .selprice
-        %p.selprice-main 価格（¥300〜9,999,999）
-        .selprice-title
-          %label 販売価格
-          %span.required 必須
-        .selprice-function
-          .selprice-function_input
-            %input.selprice-text{:placeholder => '0', :type => 'text'}
-        %p.selprice-error 300以上9999999以下で入力してください
-    %hr
-    .selmain-form_box
-      .selsubmit
-        .selsubmit-button
-          %input.selsubmit-button_sell{type: "submit", value: "出品する"} 
-          %input.selsubmit-button_save{type: "submit", value: "下書きに保存"} 
-          = link_to "#", class: "selsubmit-button_back" do
-            もどる
-
-
+  = form_with model: @item, class: :form, local: true do |form|
+    %form.selmain-form
+      .selmain-form_box
+        .selimage
+          .selimage-title
+            %label 出品画像
+            %span.required 必須
+          %p 最大10枚までアップロードできます
+          .selimage-function
+            .selimage-function_input
+              %label.clkarea
+                %input.clkarea-input{:type => 'file'}
+                = icon('fa', 'camera', class: 'clkarea-icon')
+                %p.clkarea-text クリックしてファイルをアップロード
+                = form.fields_for :images do |i|
+                  = i.file_field :image
+                
+          %p.selimage-error 入力してください
+      %hr
+      .selmain-form_box
+        .selname
+          .selname-title
+            %label 商品名
+            %span.required 必須
+          .selname-function
+            .selname-function_input
+              -# %input.selname-text{:placeholder => '40文字まで', :type => 'text'}
+              = form.text_field :name, :placeholder => '40文字まで', :class => 'selname-text'
+          %p.selname-error 入力してください
+        .selspace
+        .selname
+          .selname-title
+            %label 商品の説明
+            %span.required 必須
+          .selname-function
+            .selname-function_input
+              -# %input.selexplanation-text{:placeholder => '1,000文字以内', :type => 'text'}
+              = form.text_area :explanation, :placeholder => '1,000文字以内', :class => 'selexplanation-text'
+          %p 0/1000
+          %p.selexplanation-error 入力してください
+      %hr
+      .selmain-form_box
+        .seldetail
+          %p.seldetail-main 商品の詳細
+          .seldetail-title
+            %label カテゴリー
+            %span.required 必須
+          .seldetail-function
+            .seldetail-function_input
+              = form.select :category_id, Category.all.map { |category|[category.name, category.id] }, { include_blank: "選択して下さい", selected: 0 }, { class: "selcategory-select" }
+          %p.selcategory-error 選択してください
+        .selspace
+          .seldetail-title
+            %label サイズ
+            %span.required 必須
+          .seldetail-function
+            .seldetail-function_input
+              = form.text_field :size, :placeholder => 'サイズ', :class => 'selname-text'
+          %p.selcategory-error 入力して下さい
+        .selspace
+          .seldetail
+          .seldetail-title
+            %label ブランド
+            %span.discretion 任意
+          .seldetail-function
+            .seldetail-function_input
+              -# %input.selbrand-text{:placeholder => '例）シャネル', :type => 'text'}
+              = form.text_field :brand_name, :placeholder => '例）シャネル', :class => 'selbrand-text'
+        .selspace
+        .seldetail
+          .seldetail-title
+            %label 商品の状態
+            %span.required 必須
+          .seldetail-function
+            .seldetail-function_input
+              = form.select :condition_id, Status.all.map { |status|[status.name, status.id] }, { include_blank: "選択して下さい", selected: 0 }, { class: "selstatus-select" }
+          %p.selstatus-error 選択してください
+      %hr
+      .selmain-form_box
+        .seldelovery
+          %p.seldelovery-main 配送について？
+          .seldelovery-title
+            %label 配送料の負担
+            %span.required 必須
+          .seldelovery-function
+            .seldelovery-function_input
+              -# %select.seldelfee-select
+              -#   %option{:value => '0'}選択してください
+              = form.select :delivery_fee_id, DeliveryFee.all.map { |status|[status.name, status.id] }, { include_blank: "選択して下さい", selected: 0 }, { class: "seldelfee-select" }
+          %p.seldelfee-error 選択してください
+        .selspace
+        .seldelovery
+          .seldelovery-title
+            %label 発送元の地域
+            %span.required 必須
+          .seldelovery-function
+            .seldelovery-function_input
+              -# %select.selshiori-select
+              -#   %option{:value => '0'}選択してください
+              = form.select :prefecture_id, Prefecture.all.map { |status|[status.name, status.id] }, { include_blank: "選択して下さい", selected: 0 }, { class: "selshiori-select" }
+          %p.selshiori-error 選択してください
+        .selspace
+        .seldelovery
+          .seldelovery-title
+            %label 発送までの日数
+            %span.required 必須
+          .seldelovery-function
+            .seldelovery-function_input
+              -# %select.selshiday-select
+              -#   %option{:value => '0'}選択してください
+              = form.select :delivery_day_id, DeliveryDay.all.map { |status|[status.name, status.id] }, { include_blank: "選択して下さい", selected: 0 }, { class: "selshiori-select" }
+          %p.selshiday-error 選択してください
+      %hr
+      .selmain-form_box
+        .selprice
+          %p.selprice-main 価格（¥300〜9,999,999）
+          .selprice-title
+            %label 販売価格
+            %span.required 必須
+          .selprice-function
+            .selprice-function_input
+              -# %input.selprice-text{:placeholder => '0', :type => 'text'}
+              = form.text_field :price, :placeholder => '0', :class => 'selprice-text'
+          %p.selprice-error 300以上9999999以下で入力してください
+      %hr
+      .selmain-form_box
+        .selsubmit
+          .selsubmit-button
+            = form.submit '出品する', :class => 'selsubmit-button_sell'
+            -# %input.selsubmit-button_sell{type: "submit", value: "出品する"} 
+            = form.submit '下書きに保存', :class => 'selsubmit-button_save'
+            -# %input.selsubmit-button_save{type: "submit", value: "下書きに保存"} 
+            
+            -# ↓一覧画面にもどるではなく、全画面にもどるに修正したい
+            = link_to items_path, class: "selsubmit-button_back" do
+              もどる

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -9,13 +9,27 @@
           %p 最大10枚までアップロードできます
           .selimage-function
             .selimage-function_input
-              %label.clkarea
-                %input.clkarea-input{:type => 'file'}
-                = icon('fa', 'camera', class: 'clkarea-icon')
-                %p.clkarea-text クリックしてファイルをアップロード
+              %label.clkarea#image-box
+                -# %input.clkarea-input{:type => 'file'}
+                -# = icon('fa', 'camera', class: 'clkarea-icon')
+                -# %p.clkarea-text クリックしてファイルをアップロード
+                -# #previews
+                -#   - if @item.persisted?
+                -#     - @item.images.each_with_index do |image, i|
+                -#       = image_tag image.image.url, data: { index: i }, width: "100", height: '100'
                 = form.fields_for :images do |i|
-                  = i.file_field :image
-                
+                  .js-file_group{"data-index" => "#{i.index}"}
+                    = i.file_field :image ,:class => 'js-file'
+                    %br/
+                    %span.js-remove 削除
+
+                -# = f.fields_for :images do |image|
+                -#   .js-file_group{"data-index" => "#{image.index}"}
+                -#     = image.file_field :src, class: 'js-file'
+                -#     %br/
+                -#     %span.js-remove 削除
+
+
           %p.selimage-error 入力してください
       %hr
       .selmain-form_box


### PR DESCRIPTION
# What
商品出品機能を実装。（未完）

# Why
商品のデータ登録まで機能を実装。
他の画面で出品したデータを元に開発を進めるため最低限のデータ登録までできた段階で一度マージする。
未実装の開発は別にブランチで進める。

以下は未実装の機能。

- デザイン調整
- 添付イメージの表示
- バリデーション
- 商品説明の文字数表示
- 下書き保存（できれば）
