### PR TITLE
ユーザー新規登録画面のマークアップを修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,12 +2,14 @@
 @import "base/base";
 @import "font-awesome-sprockets";
 @import "font-awesome";
+@import "modules/users_new";
 @import "modules/users_new1";
+@import "modules/users_new2";
+@import "modules/users_new3";
 @import "modules/items_index";
 @import "modules/items_new";
 @import "modules/items_show";
 @import "modules/users_index";
-@import "modules/users_new";
 @import "modules/users_logout";
 @import "modules/users_credit-regist";
 @import "purchases/index";

--- a/app/views/users/new1.html.haml
+++ b/app/views/users/new1.html.haml
@@ -1,4 +1,4 @@
-%body.maim1
+%body.main1
   .page1
     .asec.apadmid.auwork
       .asec.aspacnone.aunav

--- a/app/views/users/new2.html.haml
+++ b/app/views/users/new2.html.haml
@@ -1,4 +1,4 @@
-%body.maim2
+%body.main2
   .page1
     .asec.apadmid.auwork
       .asec.aspacnone.aunav

--- a/app/views/users/new3.html.haml
+++ b/app/views/users/new3.html.haml
@@ -1,4 +1,4 @@
-%body.maim3
+%body.main3
   .page1
     .asec.apadmid.auwork
       .asec.aspacnone.aunav


### PR DESCRIPTION
# What
CSSがあたっていなかったユーザー新規登録のビューを編集しました。
┗new.html.haml〜new3.html.hamlのクラス名を修正。

# Why
本番環境で新規登録画面を表示するため。

マークアップのスプリントレビューのための修正なのでサーバーサイドの実装後には再度編集します。