### PR TITLE
itemモデルからmount_uploaderを消去

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -20,6 +20,4 @@ class Item < ApplicationRecord
   # validates :size, presence: true
 
   accepts_nested_attributes_for :images, allow_destroy: true
-
-  mount_uploader :image, ImageUploader
 end


### PR DESCRIPTION
バグ修正。
商品登録ができなくなるため。