### PR TITLE
バリデーションエラーでバグがあったため修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -22,13 +22,17 @@ class ItemsController < ApplicationController
   end
 
   def create
-    # ステータスの状態を「出品中：１」にして登録する
+    @submit_btn = ['new','出品する']
+    # バリデーションチェックで引っかかって出品画面に戻ったとき、上の変数がないとエラーになる。
     @status = 1
+    # ステータスの状態を「出品中：１」にして登録する
     @item = Item.new(item_params)
     if @item.save
       redirect_to item_path(@item)
     else
-      render 'new'
+      render :new
+      # 「render :new」ではなく「redirect_to」でnew画面を呼び出したいがエラーメッセージが表示されなくなってしまう
+      # redirect_toにしてエラーメッセージをセッションで表示する方法に修正したい。
     end
   end
 
@@ -38,6 +42,7 @@ class ItemsController < ApplicationController
   end
 
   def update
+    @submit_btn = ['edit','更新する']
     # ステータスの状態を「出品中：１」にして登録する
     @status = 1
     if @item.update(item_params)


### PR DESCRIPTION
# What
バリデーションエラーで出品画面にもどるとエラーになってしまうバグを修正

# Why
登録に失敗すると
createメソッドでnew画面を呼び出しているが
New画面に必要な変数を渡せていなかった。
Createアクションにも変数を追加することでエラーを回避できた。

■新たな課題
保存で失敗するとrenderでnew画面を呼び出しているが
rideirect_toで呼び出すように修正したい。
そうすればcreateアクションでnewアクションと同じ変数を書かなくてすむ。

ただ、redirect_toだとエラーメッセージ表示できなくなってしまう。
エラーメッセージをセッションで保持して表示するような方法が必要。