### PR TITLE
商品編集画面のカテゴリー選択を実装

### DIFF
--- a/app/assets/javascripts/items_new_category.js
+++ b/app/assets/javascripts/items_new_category.js
@@ -32,12 +32,12 @@ $(function(){
   }
   // 親カテゴリー選択後のイベント
   $('#parent_category').on('change', function(){
-    var parentCategory = document.getElementById('parent_category').value; //選択された親カテゴリーの名前を取得
+    var parentCategory = document.getElementById('parent_category').value; //選択された親カテゴリーのidを取得
     if (parentCategory != "選択して下さい"){ //親カテゴリーが初期値でないことを確認
       $.ajax({
-        url: 'get_category_children',
+        url: '/items/get_category_children',
         type: 'GET',
-        data: { parent_name: parentCategory },
+        data: { parent_id: parentCategory },
         dataType: 'json'
       })
       .done(function(children){
@@ -66,7 +66,7 @@ $(function(){
     var childId = $('#child_category option:selected').data('category'); //選択された子カテゴリーのidを取得
     if (childId != "選択して下さい"){ //子カテゴリーが初期値でないことを確認
       $.ajax({
-        url: 'get_category_grandchildren',
+        url: '/items/get_category_grandchildren',
         type: 'GET',
         data: { child_id: childId },
         dataType: 'json'

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -20,7 +20,7 @@ class ItemsController < ApplicationController
     @item = Item.new
     @item.images.new
     # @item.users << current_user
-    @category_parents = Category.where('ancestry IS NULL').map{ |category|[category.name, category.name] }
+    @category_parents = Category.where('ancestry IS NULL').map{ |category|[category.name, category.id] }
   end
 
   def create
@@ -41,9 +41,10 @@ class ItemsController < ApplicationController
   def edit
     # 登録ボタン名
     @submit_btn = ['edit','更新する']
-    # @category_parents = Category.where('ancestry IS NULL').map{ |category|[category.name, category.name] }
-    # @category_childs = @item.category_id.parent.parent.children.map{ |category|[category.name, category.id] }
-    # @category_grandchilds = @item.category_id.parent.children.map{ |category|[category.name, category.id] }
+    @category_parents = Category.where('ancestry IS NULL').map{ |category|[category.name, category.id] }
+    @category_childs = @item.category.parent.parent.children.map{ |category|[category.name, category.id] }
+    @category_grandchilds = @item.category.parent.children.map{ |category|[category.name, category.id] }
+    # binding.pry
   end
 
   def update
@@ -93,7 +94,7 @@ class ItemsController < ApplicationController
 
   # 親カテゴリーが選択された際に動く(Ajax)
   def get_category_children
-    @category_children = Category.find_by(name: "#{params[:parent_name]}", ancestry: nil).children
+    @category_children = Category.find_by(id: "#{params[:parent_id]}", ancestry: nil).children
   end
 
   # 子カテゴリーが選択された際に動く(Ajax)

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -67,15 +67,15 @@
               .seldetail-function_input
                 = form.select :parent_id, @category_parents, { include_blank: "選択して下さい"}, { class: "selcategory-select", id: 'parent_category' }
           - if @submit_btn[0] == 'edit'
-            -# .seldetail-function
-            -#   .seldetail-function_input
-            -#     = form.select parent_id, @category_parents, { include_blank: "選択して下さい", selected: @item.category_id.parent.parent.id }, { class: "selcategory-select", id: 'parent_category' }
-            -# -# .seldetail-function
-            -#   .seldetail-function_input
-            -#     = form.select :child_id, @category_childs, { include_blank: "選択して下さい", selected: @item.category_id.parent.id }, { class: "selcategory-select", id: 'child_category' }
-            -# .seldetail-function
-            -#   .seldetail-function_input
-            -#     = form.select :category_id, @category_grandchilds, { include_blank: "選択して下さい", selected: @item.category_id }, { class: "selcategory-select", id: 'grandchild_category' }
+            .seldetail-function
+              .seldetail-function_input
+                = form.select :parent_id, @category_parents, { include_blank: "選択して下さい", selected: @item.category.parent.parent.id }, { class: "selcategory-select", id: 'parent_category' }
+            .seldetail-function#children_wrapper
+              .seldetail-function_input
+                = form.select :child_id, @category_childs, { include_blank: "選択して下さい", selected: @item.category.parent.id }, { class: "selcategory-select", id: 'child_category' }
+            .seldetail-function#grandchildren_wrapper
+              .seldetail-function_input
+                = form.select :category_id, @category_grandchilds, { include_blank: "選択して下さい", selected: @item.category_id }, { class: "selcategory-select", id: 'grandchild_category' }
         %p.selcategory-error 選択してください
         -# ↓カテゴリによって表示する内容、ひとまず条件なしで表示
         .selspace

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -1,5 +1,5 @@
 - if user_signed_in?
-  = link_to new_item_path do
+  = link_to new_item_path, data: {"turbolinks" => false} do
     .salebtn
       .salebtn-name
         出品

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -74,7 +74,7 @@
                   %td
                     = @item.delivery_day.name
           - if current_user == @item.user
-            = link_to edit_item_path, class: "o3btninedit" do
+            = link_to edit_item_path, class: "o3btninedit", data: {"turbolinks" => false} do
               商品の情報を編集する
           - else
             = link_to items_path, class: "o3btninbuy" do

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,4 +1,4 @@
-= link_to '#' do
+= link_to new_item_path, data: {"turbolinks" => false} do
   .salebtn
     .salebtn-name
       出品


### PR DESCRIPTION
#What
・商品編集画面で、カテゴリーの登録情報を表示させる。
・商品編集画面でも同じJSを使ってカテゴリー選択を変更できるように修正。
・商品出品ページ及び商品編集ページをリロードしないとJSが実行されない問題を解消。
　（トップページの出品アイコン、マイページの出品アイコン、商品詳細ページの「編集する」ボタンのlink_toへ設定を追記した）

#Why
・編集ページでもカテゴリー選択を変えられるようにしないとアプリとして不便。
