### PR TITLE
PAY.JPの秘密鍵の参照場所の修正漏れ

### DIFF
--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -41,7 +41,7 @@ class CardsController < ApplicationController
     card = Card.where(user_id: current_user.id).first
     if card.blank?
     else
-      Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
+      Payjp.api_key = Rails.application.credentials.dig(:payjp, :PAYJP_SECRET_KEY)
       customer = Payjp::Customer.retrieve(card.customer_id)
       customer.delete
       card.delete

--- a/app/views/cards/new.html.haml
+++ b/app/views/cards/new.html.haml
@@ -10,7 +10,7 @@
         カード番号
         %span{class:"canema-content-title_require"}
           必須
-      = f.text_field :number, {class: "canema-content-text", placeholder: "ハイフンなし、半角数字のみ", value:"4242424242424242"}
+      = f.text_field :number, {class: "canema-content-text", placeholder: "ハイフンなし、半角数字のみ"}
       .canema-content-title
         有効期限
         %span{class:"canema-content-title_require"}


### PR DESCRIPTION
# What
PAY.JPの秘密鍵の参照場所をcredentials.ymlに修正

# Why
＜ローカル環境＞
ターミナルで以下を実行。
sudo vim ~/.zshrc
export PAYJP_PRIVATE_KEY='sk_test_xxxxxxxxxxxxxxxxxxxxxxxx'
ローカル環境では成功

＜デプロイ用＞
デプロイ担当者にpayjpのAPIキーをcredential.ymlに記述してもらう
・ターミナル
EDITOR='code --wait' rails credentials:edit
・credentials.yml.enc
payjp:
PAYJP_SECRET_KEY: sk_test_シークレットキー
デプロイをしてもpayjpとの連携ができない